### PR TITLE
Add player argument to duplicator.IsAllowed

### DIFF
--- a/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua
+++ b/garrysmod/gamemodes/sandbox/entities/weapons/gmod_tool/stools/duplicator.lua
@@ -100,7 +100,7 @@ function TOOL:RightClick( trace )
 	duplicator.SetLocalPos( trace.HitPos )
 	duplicator.SetLocalAng( Angle( 0, self:GetOwner():EyeAngles().yaw, 0 ) )
 
-	local Dupe = duplicator.Copy( trace.Entity )
+	local Dupe = duplicator.Copy( trace.Entity, false, self:GetOwner() )
 
 	duplicator.SetLocalPos( Vector( 0, 0, 0 ) )
 	duplicator.SetLocalAng( Angle( 0, 0, 0 ) )


### PR DESCRIPTION
By adding a player argument to the duplicator.IsAllowed function, developers would gain control over what the duplicator is allowed to spawn as well as who is allowed or not allowed to spawn it.